### PR TITLE
fix: expose show implementation for Box

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "CAIMEOX/box",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "readme": "README.md",
   "repository": "https://github.com/CAIMEOX/box",
   "license": "Apache-2.0",

--- a/src/box.mbt
+++ b/src/box.mbt
@@ -67,7 +67,7 @@ pub fn dimensions(self : Box) -> (Int, Int) {
 /// // ***
 /// ///|
 /// ```
-impl Show for Box with to_string(self) {
+pub impl Show for Box with to_string(self) {
   let buf = @buffer.new()
   self.output(buf)
   buf.to_string()
@@ -83,7 +83,7 @@ impl Show for Box with to_string(self) {
 /// // ***
 /// // ***
 /// ```
-impl Show for Box with output(self, logger) {
+pub impl Show for Box with output(self, logger) {
   logger.write_string(self.data.join("\n"))
 }
 

--- a/src/box.mbti
+++ b/src/box.mbti
@@ -25,6 +25,7 @@ fn Box::height(Self) -> Int
 fn Box::heighten(Self, Int, align~ : Vertical = ..) -> Self
 fn Box::widen(Self, Int, align~ : Horizontal = ..) -> Self
 fn Box::width(Self) -> Int
+impl Show for Box
 
 pub(all) enum Horizontal {
   Left

--- a/src/examples_test.mbt
+++ b/src/examples_test.mbt
@@ -342,7 +342,6 @@ test "mandelbrot set" {
       #|                                        
       #|                                        
       #|                                        
-
     ,
   )
 }


### PR DESCRIPTION
It may be a mistake that the show implementation for Box is private in this module. 

The PR addresses this issue and updates the `example.mbt` to use a black-box test, ensuring the API is exported correctly. 